### PR TITLE
allow unpublished queries to be used as alerts

### DIFF
--- a/client/app/pages/alert/index.js
+++ b/client/app/pages/alert/index.js
@@ -48,7 +48,7 @@ function AlertCtrl($routeParams, $location, $sce, toastr, currentUser, Query, Ev
       return;
     }
 
-    Query.search({ q: term }, (results) => {
+    Query.search({ q: term, include_drafts: true }, (results) => {
       this.queries = results;
     });
   };


### PR DESCRIPTION
Still can not use unpublished queries on dashboards.